### PR TITLE
Adding an implementation for Logical Plan (MQE4)

### DIFF
--- a/mini-query-engine/mqe4/mqe/core/datasources.py
+++ b/mini-query-engine/mqe4/mqe/core/datasources.py
@@ -1,0 +1,19 @@
+from typing import Iterator
+
+from core.tables import DataBatch, TableSchema
+
+
+class DataSource:
+    """
+    Mock implementation. The implementation will be in future articles.
+    """
+
+    def schema(self) -> TableSchema:
+        """
+        Return the schema for the underlying data source.
+        """
+        raise NotImplementedError
+
+    def scan(self, projection: list[str]) -> Iterator[DataBatch]:
+        """Scan the data source, selecting the specified columns"""
+        raise NotImplementedError

--- a/mini-query-engine/mqe4/mqe/core/logical_plan.py
+++ b/mini-query-engine/mqe4/mqe/core/logical_plan.py
@@ -1,16 +1,46 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from core.datasources import DataSource
 from core.tables import SchemaField, TableSchema
 
 
 class LogicalPlan:
     """
-    TODO MQE4
+    A logical plan represents a data transformation or action that
+    returns a relation (a set of tuples).
     """
 
     def schema(self) -> TableSchema:
         """
-        TODO MQE4
+        Returns the schema of the data that will be produced by this logical plan.
         """
         raise NotImplementedError
+
+    def children(self) -> list["LogicalPlan"]:
+        """
+        Returns the children (inputs) of this logical plan.
+        """
+        raise NotImplementedError
+
+    def explain(self, verbose: bool = True) -> str:
+        """
+        Pretty-print the logical plan tree (similar to SQL EXPLAIN).
+
+        - Root is printed without tree connector.
+        - Children are printed as a tree with └── / ├── connectors.
+        - verbose=True appends the output schema to each node.
+        """
+        lines: list[str] = [_format_plan_line(self, verbose=verbose)]
+
+        children = self.children()
+        for i, child in enumerate(children):
+            is_last = i == (len(children) - 1)
+            lines.extend(
+                _explain_lines(child, prefix="", is_last=is_last, verbose=verbose)
+            )
+
+        return "\n".join(lines)
 
 
 class LogicalExpr:
@@ -26,3 +56,157 @@ class LogicalExpr:
         the resulting SchemaField (name and data type).
         """
         raise NotImplementedError
+
+
+@dataclass
+class Scan(LogicalPlan):
+    """
+    Scan represents reading data from a DataSource with an optional projection.
+
+    Scan is a leaf node in the logical plan tree.
+    """
+
+    source_uri: str
+    data_source: DataSource
+    projection: Optional[list[str]] = None
+    _schema: TableSchema = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._schema: TableSchema = self._derive_schema()
+
+    def schema(self) -> TableSchema:
+        return self._schema
+
+    def _derive_schema(self) -> TableSchema:
+        schema: TableSchema = self.data_source.schema()
+
+        if not self.projection:
+            return schema
+
+        # Validate projection early (planning-time)
+        available: set[str] = {f.name for f in schema.fields}
+        missing: list[str] = [name for name in self.projection if name not in available]
+        if missing:
+            raise ValueError(
+                f"Scan projection contains unknown columns: {missing}. "
+                f"Available columns: {sorted(available)}"
+            )
+
+        return schema.select(self.projection)
+
+    def children(self) -> list[LogicalPlan]:
+        return []
+
+    def __str__(self) -> str:
+        if not self.projection:
+            return f"Scan: {self.source_uri}; projection=None"
+        return f"Scan: {self.source_uri}; projection={self.projection}"
+
+
+@dataclass
+class Projection(LogicalPlan):
+    """
+    Projection applies a list of expressions to its input and produces a new schema.
+
+    Example:
+        SELECT a, b, (price * qty) AS total FROM t
+    """
+
+    input: LogicalPlan
+    exprs: list[LogicalExpr]
+    _schema: TableSchema = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._schema: TableSchema = TableSchema(
+            [expr.to_field(self.input) for expr in self.exprs]
+        )
+
+    def schema(self) -> TableSchema:
+        return self._schema
+
+    def children(self) -> list[LogicalPlan]:
+        return [self.input]
+
+    def __str__(self) -> str:
+        joined: str = ", ".join(str(e) for e in self.exprs)
+        return f"Projection: {joined}"
+
+
+@dataclass
+class Filter(LogicalPlan):
+    """
+    Filter selects rows from its input based on a boolean expression.
+    Equivalent to SQL WHERE.
+    """
+
+    input: LogicalPlan
+    expr: LogicalExpr
+    _schema: TableSchema = field(init=False)
+
+    def __post_init__(self) -> None:
+        # Filter does not change schema, so we can cache it
+        self._schema: TableSchema = self.input.schema()
+
+    def schema(self) -> TableSchema:
+        return self._schema
+
+    def children(self) -> list[LogicalPlan]:
+        return [self.input]
+
+    def __str__(self) -> str:
+        return f"Filter: {self.expr}"
+
+
+def print_logical_plan(
+    plan: LogicalPlan, prefix: str = "", is_last: bool = True
+) -> str:
+    """
+    Format a logical plan as a readable tree.
+    Example:
+        Projection: #id, #name
+        └── Filter: #state = 'CO'
+            └── Scan: employee.csv; projection=None
+    """
+    connector: str = "└── " if is_last else "├── "
+    line: str = f"{prefix}{connector}{plan}\n"
+
+    children: list[LogicalPlan] = plan.children()
+    for i, child in enumerate(children):
+        last: bool = i == len(children) - 1
+        extension: str = "    " if is_last else "│   "
+        line += print_logical_plan(child, prefix + extension, last)
+
+    return line
+
+
+def _format_plan_line(plan: LogicalPlan, verbose: bool) -> str:
+    if not verbose:
+        return str(plan)
+
+    schema = plan.schema()
+    fields = ", ".join(f"{f.name}:{f.data_type}" for f in schema.fields)
+    return f"{plan}  [{fields}]"
+
+
+def _explain_lines(
+    plan: LogicalPlan,
+    prefix: str,
+    is_last: bool,
+    verbose: bool,
+) -> list[str]:
+    connector = "└── " if is_last else "├── "
+    line = f"{prefix}{connector}{_format_plan_line(plan, verbose=verbose)}"
+
+    children = plan.children()
+    if not children:
+        return [line]
+
+    next_prefix = prefix + ("    " if is_last else "│   ")
+    lines = [line]
+    for i, child in enumerate(children):
+        last = i == (len(children) - 1)
+        lines.extend(
+            _explain_lines(child, prefix=next_prefix, is_last=last, verbose=verbose)
+        )
+
+    return lines

--- a/mini-query-engine/mqe4/mqe/core/tables.py
+++ b/mini-query-engine/mqe4/mqe/core/tables.py
@@ -49,6 +49,29 @@ class TableSchema:
         if len(names) != len(set(names)):
             raise ValueError("TableSchema contains duplicate field names")
 
+
+    def select(self, names: list[str]) -> "TableSchema":
+        """
+        Return a new TableSchema containing only fields listed in `names`.
+
+        - preserves the order of `names`
+        - raises a clear error if any column is missing
+        """
+        if not names:
+            return TableSchema([])
+
+        index:dict[str, SchemaField] = {f.name: f for f in self.fields}
+
+        missing:list[str] = [name for name in names if name not in index]
+        if missing:
+            raise ValueError(
+                f"Unknown columns in projection: {missing}. "
+                f"Available columns: {sorted(index.keys())}"
+            )
+
+        selected_fields:list[SchemaField] = [index[name] for name in names]
+        return TableSchema(selected_fields)
+
     def to_arrow(self) -> pa.Schema:
         """
         Convert this TableSchema into a pyarrow.Schema.

--- a/mini-query-engine/mqe4/mqe/demo.py
+++ b/mini-query-engine/mqe4/mqe/demo.py
@@ -1,1 +1,58 @@
+import pyarrow as pa
 
+from core.datasources import DataSource
+from core.logical_expr import col
+from core.logical_plan import Filter, Projection, Scan
+from core.tables import SchemaField, TableSchema
+
+# --- Minimal DataSource stub (for planning only) ----------------------------
+
+class FakeDataSource(DataSource):
+    def __init__(self, schema: TableSchema):
+        self._schema = schema
+
+    def schema(self) -> TableSchema:
+        return self._schema
+
+    def scan(self, projection: list[str]):
+        raise NotImplementedError("This demo builds logical plans only")
+
+# -------------------------------
+
+def main() -> None:
+    # 1) Define schema
+    schema: TableSchema = TableSchema(
+        fields=[
+            SchemaField("id", pa.int64()),
+            SchemaField("first_name", pa.string()),
+            SchemaField("state", pa.string()),
+        ]
+    )
+
+    # 2) Create a fake source
+    ds: DataSource = FakeDataSource(schema)
+
+    # 3) Build logical plan:
+    # SELECT id, first_name
+    # FROM employee.csv
+    # WHERE state = 'CO'
+    scan: Scan = Scan(source_uri="employee.csv", data_source=ds)
+
+    plan: Projection = Projection(
+        input=Filter(
+            input=scan,
+            expr=(col("first_name") == "Niko"),
+        ),
+        exprs=[(col("id") * 2).as_("new_id"), col("first_name")],
+    )
+
+    # 4) Print verbose explain (with schema at each node)
+    print(plan.explain())
+
+    # 5) Print the plan (without schema at each node)
+    print()
+    print(plan.explain(verbose=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/mini-query-engine/mqe4/mqe/uv.lock
+++ b/mini-query-engine/mqe4/mqe/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "mini-query-engine"
-version = "0.1.3"
+version = "0.1.4"
 source = { virtual = "." }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
Added the initial logical plan layer (Scan, Filter, Projection) with schema inference and plan explain output. Includes a minimal DataSource stub and a demo example.

- logical plan nodes: Scan, Filter, Projection
- Implement schema inference via schema() + expr.to_field(input)
- explain(verbose=...) to print the plan tree
- TableSchema.select() for Scan projection