### PR TITLE
Adding an implementation for DataFrame API

### DIFF
--- a/mini-query-engine/mqe6/README.md
+++ b/mini-query-engine/mqe6/README.md
@@ -23,7 +23,10 @@ TODO
         ├── logical_expr.py     # Expression DSL (logical layer)
         ├── datasources.py      # Data sources (e.g., InMemoryDataSource)
         ├── physical_plan.py    # Physical operators + explain(): ScanExec/FilterExec/ProjectionExec
-        └── physical_expr.py    # Executable expressions (Arrow-first evaluation)
+        └── planer.py           # TODO
+        └── frames.py           # TODO
+        └── context.py          # TODO
+        └── optimizer.py        # TODO
 ---
 
 ## 🚀 Getting Started

--- a/mini-query-engine/mqe6/mqe/core/__init__.py
+++ b/mini-query-engine/mqe6/mqe/core/__init__.py
@@ -1,0 +1,16 @@
+from .context import ExecutionContext
+from .datatypes import ArrowColumn
+from .frames import DataFrame, LazyFrame
+from .logical_expr import col
+from .tables import DataBatch, SchemaField, TableSchema
+
+__all__ = [
+    "ExecutionContext",
+    "DataFrame",
+    "LazyFrame",
+    "DataBatch",
+    "TableSchema",
+    "SchemaField",
+    "ArrowColumn",
+    "col",
+]

--- a/mini-query-engine/mqe6/mqe/core/context.py
+++ b/mini-query-engine/mqe6/mqe/core/context.py
@@ -1,0 +1,75 @@
+from typing import Any, Iterator, Optional
+
+import pyarrow as pa
+
+from core.datasources import DataSource, InMemoryDataSource
+from core.datatypes import ArrowColumn
+from core.frames import LazyFrame
+from core.logical_plan import LogicalPlan, Scan
+from core.optimizer import Optimizer
+from core.physical_plan import PhysicalPlan
+from core.planner import Planner
+from core.tables import DataBatch, SchemaField, TableSchema
+
+
+class ExecutionContext:
+    """
+    Main entry point, similar to Spark/Polars context.
+
+    Provides:
+      - from_batches(...)
+      - from_dict(...)
+      - execute(plan)
+    """
+
+    def from_batches(
+        self, batches: list[DataBatch], schema: Optional[TableSchema] = None
+    ) -> LazyFrame:
+        """
+        Build a LazyFrame on top of in-memory DataBatches.
+        If schema is None, it will be inferred from the first batch.
+        """
+        ds: DataSource = InMemoryDataSource(data=batches, _schema=schema)
+        plan: Scan = Scan(source_uri="in_memory", data_source=ds, projection=[])
+        return LazyFrame(plan, self)
+
+    def from_dict(self, data: dict[str, list[Any]]) -> LazyFrame:
+        """
+        Build a LazyFrame from Python dict-of-lists.
+
+        Example:
+          ctx.from_dict({"id":[1,2], "name":["a","b"]})
+        """
+        if not data:
+            raise ValueError("from_dict() expects a non-empty dict of columns")
+
+        lengths: set[int] = {len(v) for v in data.values()}
+        if len(lengths) != 1:
+            raise ValueError(f"All columns must have the same length, got: {lengths}")
+
+        fields: list[SchemaField] = []
+        arr_cols: list[ArrowColumn] = []
+
+        for name, values in data.items():
+            arr: pa.Array = pa.array(values)
+            fields.append(SchemaField(name, arr.type))
+            arr_cols.append(ArrowColumn(arr))
+
+        schema: TableSchema = TableSchema(fields=fields)
+        batch: DataBatch = DataBatch(schema=schema, fields=arr_cols)
+
+        return self.from_batches([batch], schema=schema)
+
+    def execute(self, plan: LogicalPlan) -> Iterator[DataBatch]:
+        """
+        Execute a logical plan:
+          logical plan -> optimized logical plan -> physical plan -> execute
+        """
+
+        optimized: LogicalPlan = Optimizer().optimize(plan)  # just a dummy
+        physical_plan: PhysicalPlan = Planner().create_physical_plan(optimized)
+        return physical_plan.execute()
+
+    def generate_physical_plan(self, plan: LogicalPlan) -> PhysicalPlan:
+        optimized: LogicalPlan = Optimizer().optimize(plan)  # just a dummy
+        return Planner().create_physical_plan(optimized)

--- a/mini-query-engine/mqe6/mqe/core/datasources.py
+++ b/mini-query-engine/mqe6/mqe/core/datasources.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Iterator, Optional
 
-from core.tables import DataBatch, TableSchema
+from core.tables import ColumnData, DataBatch, TableSchema
 
 
 class DataSource:
@@ -39,9 +39,11 @@ class InMemoryDataSource(DataSource):
                 raise ValueError(
                     "Cannot infer schema: data is empty and schema was not provided"
                 )
-            self._schema = self.data[0].schema
+            self._schema: TableSchema = self.data[0].schema
 
-        self._name_to_index = {f.name: i for i, f in enumerate(self._schema.fields)}
+        self._name_to_index: dict[str, int] = {
+            f.name: i for i, f in enumerate(self._schema.fields)
+        }
 
     def schema(self) -> TableSchema:
         assert self._schema is not None
@@ -52,7 +54,7 @@ class InMemoryDataSource(DataSource):
             yield from self.data
             return
 
-        schema = self.schema()
+        schema: TableSchema = self.schema()
 
         indices: list[int] = []
         for name in projection:
@@ -61,8 +63,8 @@ class InMemoryDataSource(DataSource):
                 raise ValueError(f"Column '{name}' not found in schema")
             indices.append(idx)
 
-        projected_schema = schema.select(projection)
+        projected_schema: TableSchema = schema.select(projection)
 
         for batch in self.data:
-            projected_fields = [batch.field(i) for i in indices]
+            projected_fields: list[ColumnData] = [batch.field(i) for i in indices]
             yield DataBatch(projected_schema, projected_fields)

--- a/mini-query-engine/mqe6/mqe/core/frames.py
+++ b/mini-query-engine/mqe6/mqe/core/frames.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterator, Union
+
+if TYPE_CHECKING:
+    from core.context import ExecutionContext
+
+from core.logical_expr import Column, LogicalExprNode
+from core.logical_plan import Filter, LogicalPlan, Projection
+from core.tables import DataBatch, TableSchema
+
+ExprLike = Union[str, LogicalExprNode]
+
+
+@dataclass(frozen=True)
+class LazyFrame:
+    """
+    Lazy DataFrame-like API.
+
+    Holds a LogicalPlan and builds a query tree without executing it.
+    Execution happens on collect().
+    """
+
+    _plan: LogicalPlan
+    _ctx: "ExecutionContext"
+
+    def select(self, *exprs: ExprLike) -> "LazyFrame":
+        def _to_expr(x: ExprLike) -> LogicalExprNode:
+            match x:
+                case LogicalExprNode():
+                    return x
+                case str():
+                    return Column(x)
+                case _:
+                    raise TypeError(f"Unsupported expression type: {type(x)}")
+
+        # Allow select(["a", "b"]) as convenience
+        if len(exprs) == 1 and isinstance(exprs[0], list):
+            expr_list: list[LogicalExprNode] = [_to_expr(x) for x in exprs[0]]
+        else:
+            expr_list = [_to_expr(x) for x in exprs]
+
+        return LazyFrame(Projection(self._plan, expr_list), self._ctx)
+
+    def filter(self, predicate: LogicalExprNode) -> "LazyFrame":
+        return LazyFrame(Filter(self._plan, predicate), self._ctx)
+
+    def where(self, predicate: LogicalExprNode) -> "LazyFrame":
+        return self.filter(predicate)
+
+    def schema(self) -> TableSchema:
+        return self._plan.schema()
+
+    def _execute(self) -> Iterator[DataBatch]:
+        return self._ctx.execute(self._plan)
+
+    def _collect_batches(self) -> list[DataBatch]:
+        return list(self._execute())
+
+    def collect(self) -> "DataFrame":
+        batches: list[DataBatch] = self._collect_batches()
+        return DataFrame(batches=batches, _ctx=self._ctx)
+
+    def explain(self, verbose: bool = False):
+        print("\n===== LOGICAL PLAN =====\n")
+        print(self._plan.explain(verbose))
+
+        print("\n===== PHYSICAL PLAN =====\n")
+        print(self._ctx.generate_physical_plan(self._plan).explain(verbose))
+
+
+@dataclass
+class DataFrame:
+    """
+    Eager DataFrame.
+
+    Represents materialized results in memory.
+    """
+
+    batches: list[DataBatch]
+    _ctx: "ExecutionContext"
+
+    def select(self, *exprs: ExprLike) -> "DataFrame":
+        return self.lazy().select(*exprs).collect()
+
+    def filter(self, predicate: LogicalExprNode) -> "DataFrame":
+        return self.lazy().filter(predicate).collect()
+
+    def where(self, predicate: LogicalExprNode) -> "DataFrame":
+        return self.filter(predicate)
+
+    def schema(self) -> TableSchema:
+        if not self.batches:
+            raise ValueError("DataFrame is empty, schema is unknown")
+        return self.batches[0].schema
+
+    def lazy(self) -> LazyFrame:
+        return self._ctx.from_batches(self.batches)
+
+    def __str__(self) -> str:
+        total_rows: int = sum(b.row_count() for b in self.batches)
+        total_cols: int = self.batches[0].column_count()
+        schema: str = str(self.schema())
+        header: str = (
+            f"DataFrame Summary\n"
+            f"Rows:    {total_rows}\n"
+            f"Columns: {total_cols}\n"
+            f"Batches: {len(self.batches)}\n"
+            f"Schema:  {schema}\n" + "=" * (len(str(schema)) + 10)
+        )
+
+        body = "\n\n".join(f"[Batch {i}]\n{b}" for i, b in enumerate(self.batches))
+
+        return f"{header}\n{body}"

--- a/mini-query-engine/mqe6/mqe/core/logical_expr.py
+++ b/mini-query-engine/mqe6/mqe/core/logical_expr.py
@@ -125,7 +125,7 @@ class LogicalExprNode(LogicalExpr):
         return Mod(_ensure_expr(other), self)
 
     # Aliasing
-    def as_(self, name: str) -> "Alias":
+    def alias(self, name: str) -> "Alias":
         return Alias(self, name)
 
 
@@ -243,13 +243,13 @@ class CastExpr(LogicalExprNode):
 @dataclass(frozen=True, eq=False)
 class Alias(LogicalExprNode):
     expr: LogicalExpr
-    alias: str
+    alias_: str
 
     def to_field(self, input: LogicalPlan) -> SchemaField:
-        return SchemaField(self.alias, self.expr.to_field(input).data_type)
+        return SchemaField(self.alias_, self.expr.to_field(input).data_type)
 
     def __str__(self) -> str:
-        return f"{self.expr} AS {self.alias}"
+        return f"{self.expr} AS {self.alias_}"
 
 
 @dataclass(frozen=True, eq=False)

--- a/mini-query-engine/mqe6/mqe/core/logical_plan.py
+++ b/mini-query-engine/mqe6/mqe/core/logical_plan.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Sequence
 
 from core.datasources import DataSource
 from core.tables import SchemaField, TableSchema
@@ -114,7 +114,7 @@ class Projection(LogicalPlan):
     """
 
     input: LogicalPlan
-    exprs: list[LogicalExpr]
+    exprs: Sequence[LogicalExpr]
     _schema: TableSchema = field(init=False)
 
     def __post_init__(self) -> None:

--- a/mini-query-engine/mqe6/mqe/core/optimizer.py
+++ b/mini-query-engine/mqe6/mqe/core/optimizer.py
@@ -5,6 +5,6 @@ class Optimizer:
     """
     TODO MQE8
     """
-    
+
     def optimize(self, plan: LogicalPlan) -> LogicalPlan:
         return plan

--- a/mini-query-engine/mqe6/mqe/core/physical_expr.py
+++ b/mini-query-engine/mqe6/mqe/core/physical_expr.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 

--- a/mini-query-engine/mqe6/mqe/core/physical_plan.py
+++ b/mini-query-engine/mqe6/mqe/core/physical_plan.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Iterator
+from typing import Iterator, Sequence
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -159,8 +159,8 @@ class FilterExec(PhysicalPlan):
                 # fallback: materialize predicate into Arrow array
                 pred_col = ArrowColumn(_materialize(pred_col))
 
-            mask = pred_col.array  # pa.BooleanArray
-            keep_count = count_true(mask)
+            mask: pa.BooleanArray = pred_col.array
+            keep_count: int = count_true(mask)
 
             filtered_fields: list[ColumnData] = [
                 filter_column(col, mask, keep_count) for col in batch.fields
@@ -240,7 +240,7 @@ class ProjectionExec(PhysicalPlan):
     """
 
     input: PhysicalPlan
-    exprs: list[PhysicalExpr]
+    exprs: Sequence[PhysicalExpr]
     _schema: TableSchema
 
     def __post_init__(self) -> None:

--- a/mini-query-engine/mqe6/mqe/core/planner.py
+++ b/mini-query-engine/mqe6/mqe/core/planner.py
@@ -1,0 +1,155 @@
+from dataclasses import dataclass
+
+from core.logical_expr import (
+    Add,
+    Alias,
+    And,
+    BinaryExpr,
+    CastExpr,
+    Column,
+    ColumnIndex,
+    Divide,
+    Eq,
+    Gt,
+    GtEq,
+    LiteralDouble,
+    LiteralLong,
+    LiteralString,
+    LogicalExpr,
+    Lt,
+    LtEq,
+    Multiply,
+    Neq,
+    Or,
+    Subtract,
+)
+from core.logical_plan import Filter, LogicalPlan, Projection, Scan
+from core.physical_expr import (
+    AddExpression,
+    AndExpression,
+    ColumnExpression,
+    DivideExpression,
+    EqExpression,
+    GtEqExpression,
+    GtExpression,
+    LtEqExpression,
+    LtExpression,
+    MultiplyExpression,
+    NeqExpression,
+    OrExpression,
+    PhysicalExprNode,
+    SubtractExpression,
+    lit,
+)
+from core.physical_plan import FilterExec, PhysicalPlan, ProjectionExec, ScanExec
+from core.tables import TableSchema
+
+
+@dataclass
+class Planner:
+    def create_physical_plan(self, plan: LogicalPlan) -> PhysicalPlan:
+        if isinstance(plan, Scan):
+            return ScanExec(
+                data_source=plan.data_source,
+                projection=plan.projection or [],
+            )
+
+        if isinstance(plan, Filter):
+            input_plan: PhysicalPlan = self.create_physical_plan(plan.input)
+            predicate: PhysicalExprNode = self.create_physical_expr(
+                plan.expr, input_schema=plan.input.schema()
+            )
+            return FilterExec(input=input_plan, predicate=predicate)
+
+        if isinstance(plan, Projection):
+            input_plan = self.create_physical_plan(plan.input)
+            exprs: list[PhysicalExprNode] = [
+                self.create_physical_expr(expr, input_schema=plan.input.schema())
+                for expr in plan.exprs
+            ]
+
+            # use already computed logical schema
+            out_schema: TableSchema = plan.schema()
+
+            return ProjectionExec(input=input_plan, exprs=exprs, _schema=out_schema)
+
+        raise TypeError(f"Unsupported logical plan: {type(plan).__name__}")
+
+    def create_physical_expr(self, expr: LogicalExpr, input_schema) -> PhysicalExprNode:
+        """
+        Build a physical expression bound to the given input schema.
+        input_schema: TableSchema
+        """
+
+        # Fast path: literals
+        if isinstance(expr, LiteralLong):
+            return lit(expr.n)
+
+        if isinstance(expr, LiteralDouble):
+            return lit(expr.n)
+
+        if isinstance(expr, LiteralString):
+            return lit(expr.s)
+
+        # Column ref by index
+        if isinstance(expr, ColumnIndex):
+            return ColumnExpression(expr.i)
+
+        # Alias does not exist physically, schema already contains the name
+        if isinstance(expr, Alias):
+            return self.create_physical_expr(expr.expr, input_schema)
+
+        # Column ref by name -> index binding
+        if isinstance(expr, Column):
+            idx = self._resolve_column_index(expr.name, input_schema)
+            return ColumnExpression(idx)
+
+        # Cast
+        if isinstance(expr, CastExpr):
+            return PhysicalExprNode.cast(
+                self.create_physical_expr(expr.expr, input_schema), expr.data_type
+            )
+
+        # Binary expressions
+        if isinstance(expr, BinaryExpr):
+            le: PhysicalExprNode = self.create_physical_expr(expr.le, input_schema)
+            re: PhysicalExprNode = self.create_physical_expr(expr.re, input_schema)
+
+            if isinstance(expr, Eq):
+                return EqExpression(le, re)
+            if isinstance(expr, Neq):
+                return NeqExpression(le, re)
+            if isinstance(expr, Gt):
+                return GtExpression(le, re)
+            if isinstance(expr, GtEq):
+                return GtEqExpression(le, re)
+            if isinstance(expr, Lt):
+                return LtExpression(le, re)
+            if isinstance(expr, LtEq):
+                return LtEqExpression(le, re)
+            if isinstance(expr, And):
+                return AndExpression(le, re)
+            if isinstance(expr, Or):
+                return OrExpression(le, re)
+
+            if isinstance(expr, Add):
+                return AddExpression(le, re)
+            if isinstance(expr, Subtract):
+                return SubtractExpression(le, re)
+            if isinstance(expr, Multiply):
+                return MultiplyExpression(le, re)
+            if isinstance(expr, Divide):
+                return DivideExpression(le, re)
+
+            raise TypeError(f"Unsupported binary expression: {type(expr).__name__}")
+
+        raise TypeError(f"Unsupported logical expression: {type(expr).__name__}")
+
+    def _resolve_column_index(self, name: str, input_schema: TableSchema) -> int:
+        """
+        Resolve column name -> index.
+        """
+        for i, f in enumerate(input_schema.fields):
+            if f.name == name:
+                return i
+        raise ValueError(f"No column named '{name}' in input schema")

--- a/mini-query-engine/mqe6/mqe/core/tables.py
+++ b/mini-query-engine/mqe6/mqe/core/tables.py
@@ -49,7 +49,6 @@ class TableSchema:
         if len(names) != len(set(names)):
             raise ValueError("TableSchema contains duplicate field names")
 
-
     def select(self, names: list[str]) -> "TableSchema":
         """
         Return a new TableSchema containing only fields listed in `names`.
@@ -60,16 +59,16 @@ class TableSchema:
         if not names:
             return TableSchema([])
 
-        index:dict[str, SchemaField] = {f.name: f for f in self.fields}
+        index: dict[str, SchemaField] = {f.name: f for f in self.fields}
 
-        missing:list[str] = [name for name in names if name not in index]
+        missing: list[str] = [name for name in names if name not in index]
         if missing:
             raise ValueError(
                 f"Unknown columns in projection: {missing}. "
                 f"Available columns: {sorted(index.keys())}"
             )
 
-        selected_fields:list[SchemaField] = [index[name] for name in names]
+        selected_fields: list[SchemaField] = [index[name] for name in names]
         return TableSchema(selected_fields)
 
     def to_arrow(self) -> pa.Schema:
@@ -77,6 +76,9 @@ class TableSchema:
         Convert this TableSchema into a pyarrow.Schema.
         """
         return pa.schema([field.to_arrow() for field in self.fields])
+
+    def __str__(self) -> str:
+        return ", ".join(f"{f.name}:{f.data_type}" for f in self.fields)
 
 
 @dataclass
@@ -173,18 +175,18 @@ class DataBatch:
 
         # Column headers
         col_names = [field.name for field in schema.fields]
-        col_types = [str(field.data_type) for field in schema.fields]
+        # col_types = [str(field.data_type) for field in schema.fields]
 
         lines: list[str] = []
+        header_col_names: str = "\t".join(col_names)
 
         # Visual separator
-        lines.append("———")
+        separator: str = "-" * len(header_col_names) + "-" * len(col_names) * 2
+        lines.append(separator)
         # Column names
-        lines.append("\t".join(col_names))
-        # Column types
-        lines.append("\t".join(col_types))
-        # Visual separator before data
-        lines.append("———")
+        lines.append(header_col_names)
+        # Visual separator
+        lines.append(separator)
 
         # Data rows
         for row_index in range(row_count):

--- a/mini-query-engine/mqe6/mqe/demo.py
+++ b/mini-query-engine/mqe6/mqe/demo.py
@@ -1,67 +1,30 @@
-import pyarrow as pa
-
-from core.datasources import InMemoryDataSource
-from core.datatypes import ArrowColumn
-from core.physical_expr import ColumnExpression, EqExpression, lit
-from core.physical_plan import FilterExec, ProjectionExec, ScanExec
-from core.tables import DataBatch, SchemaField, TableSchema
+from core import DataFrame, ExecutionContext, LazyFrame, col
 
 
 def main() -> None:
-    # 1) Build a single in-memory DataBatch
-    schema: TableSchema = TableSchema(
-        [
-            SchemaField("id", pa.int64()),
-            SchemaField("first_name", pa.string()),
-            SchemaField("state", pa.string()),
-        ]
+    ct: ExecutionContext = ExecutionContext()
+
+    lf: LazyFrame = ct.from_dict(
+        {
+            "id": [1, 2, 3],
+            "first_name": ["Niko", "Alice", "Joy"],
+            "state": ["CO", "CA", "NY"],
+        }
     )
 
-    data: list[ArrowColumn] = [
-        ArrowColumn(pa.array([1, 2, 3])),
-        ArrowColumn(pa.array(["Niko", "Alice", "Joy"])),
-        ArrowColumn(pa.array(["CO", "CA", "NY"])),
-    ]
-
-    batch: DataBatch = DataBatch(schema=schema, fields=data)
-
-    # 2) Create InMemoryDataSource with auto-schema inference
-    ds: InMemoryDataSource = InMemoryDataSource(data=[batch])
-
-    # 3) Build Physical Plan
-    #
-    # SQL-ish:
-    # SELECT id * 2 AS new_id, first_name
-    # FROM users (in_memory)
-    # WHERE first_name = 'Niko'
-
-    scan: ScanExec = ScanExec(data_source=ds, projection=[])  # [] means "read all"
-
-    predicate: EqExpression = EqExpression(
-        ColumnExpression(1),  # first_name
-        lit("Niko"),
+    lf = lf.filter(col("first_name") == "Niko").select(
+        "id", (col("id") * 2).alias("new_id"), "first_name"
     )
-    filter_: FilterExec = FilterExec(input=scan, predicate=predicate)
+    
+    lf.explain(True)
 
-    out_schema: TableSchema = TableSchema(
-        fields=[
-            SchemaField("new_id", pa.int64()),
-            SchemaField("first_name", pa.string()),
-        ]
-    )
-    proj: ProjectionExec = ProjectionExec(
-        input=filter_,
-        exprs=[(ColumnExpression(0) * 2).alias("new_id"), ColumnExpression(1)],
-        _schema=out_schema,
-    )
+    result: DataFrame = lf.collect()
+    print("\n===== EXAMPLE 1 =====\n")
+    print(result)
 
-    # 4) Print EXPLAIN
-    print("=== PHYSICAL PLAN ===")
-    print(proj.explain(verbose=True))
-
-    # 5) Execute and print output
-    print("\n=== OUTPUT ===")
-    print(next(proj.execute()))
+    result2: DataFrame = result.select("first_name")
+    print("\n===== EXAMPLE 2 =====\n")
+    print(result2)
 
 
 if __name__ == "__main__":

--- a/mini-query-engine/mqe6/mqe/uv.lock
+++ b/mini-query-engine/mqe6/mqe/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "mini-query-engine"
-version = "0.1.5"
+version = "0.1.6"
 source = { virtual = "." }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
This PR adds a minimal DataFrame-style API and connects the full execution path:
> DataFrame API → Logical Plan → Physical Plan → Execution (Arrow batches)

Includes:
- ExecutionContext (from_dict, from_batches, execute, generate_physical_plan)
- LazyFrame/DataFrame with select, filter/where, collect, explain
- Planner binding for expressions (column name → index) and logical→physical compilation